### PR TITLE
Fix: dark/light mode toggle (flipMode as class method)

### DIFF
--- a/_includes/mode-toggle.html
+++ b/_includes/mode-toggle.html
@@ -86,33 +86,32 @@ class ModeToggle {
       }
     }
   }
-}
 
-const toggle = new ModeToggle();
-window.modeToggle = toggle; /* expose as expected by misc.min.js */
-
-function flipMode() {
-  if (toggle.hasMode) {
-    if (toggle.isSysDarkPrefer) {
-      if (toggle.isLightMode) {
-        toggle.clearMode();
+  flipMode() {
+    if (this.hasMode) {
+      if (this.isSysDarkPrefer) {
+        if (this.isLightMode) {
+          this.clearMode();
+        } else {
+          this.setLight();
+        }
       } else {
-        toggle.setLight();
+        if (this.isDarkMode) {
+          this.clearMode();
+        } else {
+          this.setDark();
+        }
       }
     } else {
-      if (toggle.isDarkMode) {
-        toggle.clearMode();
+      if (this.isSysDarkPrefer) {
+        this.setLight();
       } else {
-        toggle.setDark();
+        this.setDark();
       }
     }
-  } else {
-    if (toggle.isSysDarkPrefer) {
-      toggle.setLight();
-    } else {
-      toggle.setDark();
-    }
+    this.notify();
   }
-  toggle.notify();
 }
+
+const modeToggle = new ModeToggle();
 </script>


### PR DESCRIPTION
Fixes modeToggle.flipMode is not a function error. Chirpy v5.6+ misc.min.js calls modeToggle.flipMode() as a method on the instance. Moved flipMode() into ModeToggle class and renamed const toggle to modeToggle.