### PR TITLE
Remove Midjourney prompts from all 8 AI blog posts

### DIFF
--- a/_posts/2026-05-01-sharingiscaring-ai-900-certification-roadmap-2026.md
+++ b/_posts/2026-05-01-sharingiscaring-ai-900-certification-roadmap-2026.md
@@ -253,5 +253,4 @@ Start with the free Microsoft Learn paths, run the free practice assessment, and
 
 ## Image Prompt
 
-> **Midjourney prompt:**
-> `abstract neural network brain made of glowing gold nodes and connections floating above a Microsoft certification badge, electric blue circuit lines in background, dark navy background, flat design illustration, gold and electric blue color scheme, clean minimal enterprise style --v 7.0`
+

--- a/_posts/2026-05-02-tip-of-the-day-build-first-copilot-studio-agent.md
+++ b/_posts/2026-05-02-tip-of-the-day-build-first-copilot-studio-agent.md
@@ -183,5 +183,4 @@ Ten minutes, no code, and you have a working AI agent backed by your own content
 
 ## Image Prompt
 
-> **Midjourney prompt:**
-> `friendly purple robot assistant emerging from a smartphone screen, surrounded by floating chat bubbles and gear icons, Microsoft purple and teal color scheme, flat design illustration, step-by-step building blocks visual, dark navy background, clean minimal style --v 7.0`
+

--- a/_posts/2026-05-03-tip-of-the-day-copilot-studio-vs-power-automate.md
+++ b/_posts/2026-05-03-tip-of-the-day-copilot-studio-vs-power-automate.md
@@ -196,5 +196,4 @@ These two tools are not competitors — they are complementary layers of the Pow
 
 ## Image Prompt
 
-> **Midjourney prompt:**
-> `split screen flat illustration, left side glowing purple Copilot Studio robot with floating chat speech bubbles, right side blue Power Automate lightning bolt with connected flow arrows and gear icons, both sides separated by a clean vertical divider, dark navy background, modern minimal enterprise design, Microsoft purple and blue color scheme --v 7.0`
+

--- a/_posts/2026-05-04-tip-of-the-day-getting-started-azure-ai-foundry.md
+++ b/_posts/2026-05-04-tip-of-the-day-getting-started-azure-ai-foundry.md
@@ -278,5 +278,4 @@ The new Azure AI Foundry portal consolidates everything you need to build produc
 
 ## Image Prompt
 
-> **Midjourney prompt:**
-> `modern AI development portal dashboard floating in dark space, holographic panels showing model cards with deployment metrics and evaluation scores, glowing Azure blue and white color scheme, futuristic flat design, clean enterprise aesthetic, multiple interconnected floating UI panels, dark navy background --v 7.0`
+

--- a/_posts/2026-05-06-sharingiscaring-microsoft-search-iq-sharepoint.md
+++ b/_posts/2026-05-06-sharingiscaring-microsoft-search-iq-sharepoint.md
@@ -219,5 +219,4 @@ For organisations investing in Microsoft 365 as their intranet platform, underst
 
 ## Image Prompt
 
-> **Midjourney prompt:**
-> `glowing magnifying glass with an AI neural network brain inside it, surrounded by floating SharePoint document icons people profile cards and knowledge graph nodes with connecting lines, Microsoft blue and gold color scheme, flat design illustration, dark navy background, clean minimal enterprise style --v 7.0`
+

--- a/_posts/2026-05-09-tip-of-the-day-customize-microsoft-search-copilot-verticals.md
+++ b/_posts/2026-05-09-tip-of-the-day-customize-microsoft-search-copilot-verticals.md
@@ -257,5 +257,4 @@ Custom Search Verticals with Copilot answers turn Microsoft Search into a precis
 
 ## Image Prompt
 
-> **Midjourney prompt:**
-> `colorful vertical search tab panels floating in a modern office environment, Copilot purple AI star icon glowing at the top, custom search result cards with filter tags and metadata columns, Microsoft blue and purple gradient color scheme, flat design illustration, dark navy background, clean enterprise aesthetic --v 7.0`
+

--- a/_posts/2026-05-10-sharingiscaring-multi-agent-workflows-copilot-studio-power-automate.md
+++ b/_posts/2026-05-10-sharingiscaring-multi-agent-workflows-copilot-studio-power-automate.md
@@ -273,5 +273,4 @@ Multi-agent architectures in Copilot Studio and Power Automate are no longer exp
 
 ## Image Prompt
 
-> **Midjourney prompt:**
-> `three interconnected AI agent robots passing glowing task packages between each other with luminous arrows, Power Automate blue lightning bolts connecting the flow, Copilot Studio purple accents on each robot, dark background, isometric flat design illustration, Microsoft purple and blue color scheme, clean enterprise style --v 7.0`
+

--- a/_posts/2026-05-11-sharingiscaring-what-are-ai-agents-m365-developers.md
+++ b/_posts/2026-05-11-sharingiscaring-what-are-ai-agents-m365-developers.md
@@ -275,5 +275,4 @@ AI agents are not magic — they are a well-defined pattern of perception, reaso
 
 ## Image Prompt
 
-> **Midjourney prompt:**
-> `friendly AI agent robot with labeled thought bubbles floating around it: perception reasoning action memory, surrounded by floating Microsoft 365 app icons Teams SharePoint Outlook, Microsoft blue and gold color scheme, clean flat design illustration, educational diagram style, dark navy background --v 7.0`
+


### PR DESCRIPTION
Removes the Midjourney image generation prompts that were included in the post content — these are for personal use only and shouldn't be visible to readers.