### PR TITLE
Fix post dates for Build 2026 posts

### DIFF
--- a/_posts/2026-06-17-sharingiscaring-github-copilot-app-agent-native-desktop.md
+++ b/_posts/2026-06-17-sharingiscaring-github-copilot-app-agent-native-desktop.md
@@ -1,7 +1,7 @@
 ---
 title: "GitHub Copilot App – The Agent-Native Desktop Experience (Technical Preview)"
 author: valeras
-date: 2026-06-17 11:00:00 +0800
+date: 2026-06-17 00:30:00 +0300
 categories:
   - SharingIsCaring
   - GitHub

--- a/_posts/2026-06-17-sharingiscaring-microsoft-build-2026-highlights.md
+++ b/_posts/2026-06-17-sharingiscaring-microsoft-build-2026-highlights.md
@@ -1,7 +1,7 @@
 ---
 title: "Microsoft Build 2026 – Agentic AI, MAI Models, and the Agent-Native Platform"
 author: valeras
-date: 2026-06-17 10:00:00 +0800
+date: 2026-06-17 00:00:00 +0300
 categories:
   - SharingIsCaring
   - AI

--- a/_posts/2026-06-17-tip-of-the-day-mai-thinking-1-azure-ai-foundry.md
+++ b/_posts/2026-06-17-tip-of-the-day-mai-thinking-1-azure-ai-foundry.md
@@ -1,7 +1,7 @@
 ---
 title: "Tip: Try MAI-Thinking-1 – Microsoft's First Reasoning Model on Azure AI Foundry"
 author: valeras
-date: 2026-06-17 12:00:00 +0800
+date: 2026-06-17 01:00:00 +0300
 categories:
   - TipOfTheDay
   - AI


### PR DESCRIPTION
Posts were using +0800 timezone which put them in the future relative to UTC build time. Changed to +0300 so Jekyll renders them correctly.